### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # StepSecurity Maintained Conventional PR Title Action
 
 Forked from: [aslafy-z/conventional-pr-title-action](https://github.com/aslafy-z/conventional-pr-title-action)

--- a/src/index.js
+++ b/src/index.js
@@ -4,21 +4,51 @@ const npa = require("npm-package-arg");
 const installPreset = require("./installPreset");
 const validateTitle = require("./validateTitle");
 const axios = require("axios");
+const fs = require("fs");
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "aslafy-z/conventional-pr-title-action";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("\u001b[1;36mStepSecurity Maintained Action\u001b[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("\u001b[32m✓ Free for public repositories\u001b[0m");
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, { timeout: 3000 });
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
-      console.error(
-        "Subscription is not valid. Reach out to support@stepsecurity.io"
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      core.error(
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`,
+      );
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`,
       );
       process.exit(1);
-    } else {
-      core.info("Timeout or API not reachable. Continuing to next step.");
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z